### PR TITLE
Multiple Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Type `String` Default `gulp-tasks`
 
 Path to folder with gulp tasks
 
+### extensions
+Type `Array` Default to keys of `required.extensions`
+
+List of extensions to filter tasks by. Example: `['js', 'coffee']`
+
 ## Test
 
 If mocha is not installed do:

--- a/index.js
+++ b/index.js
@@ -18,7 +18,13 @@ module.exports = function(options) {
 	}
 
 	var opts = _.defaults(options, defaults);
-	var isJsFile = /\.js$/i;
+	var exts = opts.extensions ||
+				require.extensions
+					? _.keys(require.extensions)
+						.map(function(e) { return e.substr(1); })
+					: ['js'];
+
+	var isJsFile = new RegExp('\\.(' + exts.join('|') + ')$', 'i');
 
 	function jsFiles(fileName) {
 		return isJsFile.test(fileName);

--- a/test/includeRequireExtensions/task.js
+++ b/test/includeRequireExtensions/task.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+	return true;
+};

--- a/test/includeRequireExtensions/task2.jscript
+++ b/test/includeRequireExtensions/task2.jscript
@@ -1,0 +1,3 @@
+module.exports = function() {
+	return true;
+};

--- a/test/test.js
+++ b/test/test.js
@@ -41,4 +41,23 @@ describe("gulp-task-loader", function() {
 			require('../index.js')('test/filterOutFiles');
 		});
 	});
+
+	describe("include extensions in require.extensions", function() {
+		var task, task2;
+
+		before(function() {
+			require.extensions['.jscript'] = require.extensions['.js'];
+			require('../index.js')('test/includeRequireExtensions');
+			task = gulp.tasks['task'];
+			task2 = gulp.tasks['task2'];
+		});
+
+		it("task.js should return true", function() {
+			expect(task.fn()).to.be.true;
+		});
+
+		it("task2.jscript should also return true", function() {
+			expect(task2.fn()).to.be.true;
+		});
+	});
 });


### PR DESCRIPTION
Includes extensions in `require.extensions` by default and adds the `extensions` option, for more control.
This way, it's possible to load tasks written in other languages, like `.coffee` files.
