### PR TITLE
Add ability to load tasks from folders. These will be loaded with a s…

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,8 @@ module.exports = function(options) {
 
 		if (stat.isFile() && byExtension(dir)) {
 			loadTask(null, dir);
-		} else {
+		} else if (!stat.isFile()) {
+			// If the entry is not a file then we know it's a folder to read
 			fs.readdirSync(
 				path.join(opts.dir, dir)
 			)

--- a/test/subtasks/annotate/add.js
+++ b/test/subtasks/annotate/add.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function() {
+	return 'add';
+};

--- a/test/subtasks/annotate/remove.js
+++ b/test/subtasks/annotate/remove.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function() {
+	return 'remove';
+};

--- a/test/test.js
+++ b/test/test.js
@@ -69,6 +69,7 @@ describe('gulp-task-loader', function() {
 
 	describe('filter non js files', function() {
 		it('should filter .jshintrc', function() {
+			require('../index.js').bind(null, 'test/filterOutFiles')()
 			expect(require('../index.js').bind(null, 'test/filterOutFiles')).to.not.throw();
 		});
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -56,6 +56,17 @@ describe('gulp-task-loader', function() {
 		});
 	});
 
+	describe('load subtasks in nested folders', function () {
+
+		it('Should load tasks in a subfolder and namespace them', function () {
+			require('../index.js')('test/subtasks');
+
+			expect(getTask('annotate:add')).to.be.defined;
+			expect(getTask('annotate:remove')).to.be.defined;
+		});
+
+	});
+
 	describe('filter non js files', function() {
 		it('should filter .jshintrc', function() {
 			expect(require('../index.js').bind(null, 'test/filterOutFiles')).to.not.throw();


### PR DESCRIPTION
Hey,

I just added the ability to load tasks from folders within the task folder specified to the loader. When these are loaded they can be used like so:

``` javascript
// Load all tasks from folder `gulp-tasks`
require('gulp-task-loader')();

gulp.watch(someFiles, ['annotate:add', 'build', 'annotate:remove']);
```

This is a feature that was a part of my own [gulp-task-loader](https://github.com/evanshortiss/gulp-task-loader), but I decided not publish it once I found out you had already done this!

I added tests for this feature and old tests are passing so I think things should be working fine.
