### PR TITLE
Added testing and a fix for directory paths that start with "./".

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,17 @@ function getDefaults() {
 	};
 }
 
+function cleanDir(options) {
+	options.dir = options.dir.replace(/^\.\//, '');
+}
+
 module.exports = function(options) {
 	if (isString(options)) {
 		options = { dir: options };
+	}
+
+	if (options) {
+		cleanDir(options);
 	}
 
 	var opts = assign(getDefaults(), options);
@@ -72,6 +80,6 @@ module.exports = function(options) {
 				});
 		}
 	}
-	
+
 	loadTasks(opts.dir);
 };

--- a/test/test.js
+++ b/test/test.js
@@ -136,4 +136,16 @@ describe('gulp-task-loader', function() {
 			});
 		});
 	});
+
+	describe('subfolder tasks referenced by ./', function () {
+		beforeEach(function() {
+			require('../index.js')('./test/subtasks');
+		});
+
+		it('Should load tasks in a subfolder and namespace them as before', function () {
+			expect(getTask('annotate:add')).to.be.defined;
+			expect(getTask('annotate:remove')).to.be.defined;
+			expect(getTask('annotate:docs:comment')).to.be.defined;
+		});
+	});
 });


### PR DESCRIPTION
I found the issue I was having was because I was referencing the task folder with ./foo/bar. The preceding ./ was causing my problem. I have fixed this in my project, but I figure that this addition to the code might save someone from trouble later.
