### PR TITLE
Fix the error : Cannot call method 'replace' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function getDefaults() {
 }
 
 function cleanDir(options) {
+	if (!options.dir) return;
 	options.dir = options.dir.replace(/^\.\//, '');
 }
 


### PR DESCRIPTION
if you provide options other than 'dir'
example that will fail: require('gulp-task-loader')({ paths: {...} });
