### PR TITLE
Feature/flexible option dir path

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,15 @@ Given the files in folder *copy* - two tasks have been created. `copy:all` & `co
 
 ## Options
 
+### gulp
+
+A gulp instance to attach tasks to. Defaults to a new instance if not provided. 
+
 ### dir
 Type `String` Default `gulp-tasks`
 
-Path to folder with gulp tasks
+Absolute path to folder with gulp tasks, (hint, use __dirname to get the absolute path from a specific module)
+You can also specify a path relative to the process working directory 
 
 ### extensions
 Type `Array` Default to keys of `require.extensions`

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var fs = require('fs');
 var path = require('path');
 var assign = require('object-assign');
+var gulp = require('gulp');
 
 function isString(str) {
 	return 'string' === typeof str;
@@ -36,7 +37,7 @@ module.exports = function(options) {
 
 	var opts = assign(getDefaults(), options);
 	var absoluteBasePath = path.resolve( opts.dir );
-	var gulp = opts.gulp || require('gulp');
+	var gulpInstance = opts.gulp || gulp;
 
 	function byExtension(fileName) {
 		var extension = path.extname(fileName);
@@ -54,7 +55,7 @@ module.exports = function(options) {
 		var dependencies = func.dependencies || [];
 		var taskName = stripExtension(task);
 		var context = {
-			gulp: opts.gulp && gulp,
+			gulp: gulpInstance,
 			opts: opts
 		};
 
@@ -63,7 +64,7 @@ module.exports = function(options) {
 			taskName = parents.join(':') + ':' + taskName;
 		}
 
-		gulp.task(taskName, dependencies, func.bind(context));
+		gulpInstance.task(taskName, dependencies, func.bind(context));
 	}
 
 	function loadTasks(currentPath) {
@@ -79,7 +80,9 @@ module.exports = function(options) {
 					loadTasks(path.join(currentPath, subPath));
 				});
 		}
+
+		return gulpInstance;
 	}
 
-	loadTasks(absoluteBasePath);
+	return loadTasks(absoluteBasePath);
 };


### PR DESCRIPTION
The current way of handling the path is forcing the opts.dir to be a relative path based on process.cwd. My change keeps the functionality but also enables to specify an absolute path.

Mainly, I changed the way that the path is provided to loadTask to generate a resolved/normalized version of the parameter, and than the rest of the process uses that path (instead of having a variable in loadTasks that is used for fsStats and then constructed another way in loadTask, using process.cwd() for modulePath).

This change is preserving the current way of providing the parameter.

I also added the possibility to provide a gulp instance in the options. This enables the usage of gulp-task-loader as a sub dependency in another module. Basically I'm using it to create a build template module. Instead of generating the builds pattern with a tool like yeoman, I'm installing my tasks as a module, and than all the apps that uses it can be update without changing their sources.

I know that you are favorizing simplicity over complexity, but I do not think those changes introduce anymore complexity, it's only adding to flexibility . 